### PR TITLE
restored baseurl for github pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,7 +23,7 @@ subtitle: Help Canadians report a cybercrime or fraud
 # When working locally use jekyll serve --baseurl '' so that you can view everything at localhost:4000
 # See http://jekyllrb.com/docs/github-pages/ for more info
 #baseurl: ''
-baseurl: ""
+baseurl: "/rcmp-report-a-cybercrime-alpha-documentation"
 
 # Author/Organization info to be displayed in the templates
 author:


### PR DESCRIPTION
# Summary | Résumé

Baseurl is restored to the name of the site on github pages

# Test instructions | Instructions pour tester la modification